### PR TITLE
Fix wrong case on include inside Vector.h

### DIFF
--- a/Vector.h
+++ b/Vector.h
@@ -32,7 +32,7 @@
 #ifndef VECTOR_H
 #define VECTOR_H JUN_2014
 
-#include <arduino.h>
+#include <Arduino.h>
 
 //as far as I can tell placement new is not included with AVR or arduino.h
 template<typename T>


### PR DESCRIPTION
Vector.h includes “arduino.h” instead of the correct “Arduino.h”. This fails on case-sensitive OSs like *NIX.
Fixes #2